### PR TITLE
Fixing `grunt build` and `grunt test`

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-cssmin": "^0.12.0",
     "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-contrib-imagemin": "^0.9.2",
+    "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",

--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -20,6 +20,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",
+    "grunt-karma": "^0.12.1",
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
     "grunt-svgmin": "^2.0.0",<% if (typescript) { %>


### PR DESCRIPTION
When I use this generator, I have to update the dependency for `grunt-contrib-imagemin` to 1.0.0 in order to get `grunt build` to work. 

Then, if I want to use `grunt test`, I have to install `grunt-karma`. I've added these dependencies to the root package so that others won't have to do these manual steps themselves.
